### PR TITLE
fix: fall back to removing text in brackets

### DIFF
--- a/translate.py
+++ b/translate.py
@@ -26,7 +26,9 @@ def translate(word, matches_to_show, from_english=False):
         print(f'no results found for "{word}"')
         return
 
-    first_matches = _get_first_matches(matches_to_show, result.translation_tuples)
+    first_matches = " - ".join(
+        _get_first_matches(matches_to_show, result.translation_tuples)
+    )
 
     with open(TXT_FILE, "a") as searched_words:
         searched_words.write(f"{word}: {first_matches}\n")
@@ -81,35 +83,35 @@ def _fetch_result(word, from_english):
         return translator.translate(word, from_language="de", to_language="en")
 
 
-def _get_first_matches(matches_to_show, translation_tuples):
-    basic_translations = _remove_translations_with_square_brackets(
-        translation_tuples
-    )
+def _get_first_matches(
+    matches_to_show: int, translation_tuples: List[tuple[str, str]]
+) -> List[str]:
+    basic_translations = _remove_translations_with_square_brackets(translation_tuples)
     # If all translations were filtered out, we still want to show the first few matches
     if not basic_translations:
         basic_translations = _remove_text_in_square_brackets_from_translation(
             translation_tuples
         )
-    first_matches = " - ".join(
-        [translation[1] for translation in basic_translations[:matches_to_show]]
-    )
+    first_matches = [
+        translation[1] for translation in basic_translations[:matches_to_show]
+    ]
     return first_matches
 
 
-def _remove_translations_with_square_brackets(translation_tuples):
+def _remove_translations_with_square_brackets(
+    translation_tuples: List[tuple[str, str]],
+) -> List[tuple[str, str]]:
     """
     Remove translations that contain square brackets, as these examples are usually not useful for quick translations.
-    :param translation_tuples: list[tuple[str, str]]
-    :return: list[tuple[str, str]]
     """
     return list(filterfalse(lambda tup: "[" in tup[1], translation_tuples))
 
 
-def _remove_text_in_square_brackets_from_translation(translation_tuples):
+def _remove_text_in_square_brackets_from_translation(
+    translation_tuples: List[tuple[str, str]],
+) -> List[tuple[str, str]]:
     """
     Remove text in square brackets from translations, as they are often not relevant for quick translations.
-    :param translation_tuples: list[tuple[str, str]]
-    :return: list[tuple[str, str]]
     """
     return list(
         map(lambda tup: (tup[0], sub(r"\[.*]", "", tup[1]).strip()), translation_tuples)

--- a/translate.py
+++ b/translate.py
@@ -1,16 +1,17 @@
 #!/usr/bin/env python3
 
+import json
 from argparse import ArgumentParser
 from datetime import datetime
 from dictcc import Dict
 from itertools import filterfalse
-import json
 from pathlib import Path
+from re import sub
 from searchedword import SearchedWord
 from typing import List
 
-TXT_FILE = 'searched_words.txt'
-JSON_FILE = 'searched_words.json'
+TXT_FILE = "searched_words.txt"
+JSON_FILE = "searched_words.json"
 
 
 def translate(word, matches_to_show, from_english=False):
@@ -20,34 +21,37 @@ def translate(word, matches_to_show, from_english=False):
         lang = "en"
     else:
         lang = "de"
-    
+
     if result.n_results == 0:
         print(f'no results found for "{word}"')
         return
 
-    basic_translations = list(filterfalse(lambda tup: '[' in tup[1], result.translation_tuples))
-    first_matches = ' - '.join([translation[1] for translation in basic_translations[:matches_to_show]])
-    with open(TXT_FILE, 'a') as searched_words:
+    first_matches = _get_first_matches(matches_to_show, result.translation_tuples)
+
+    with open(TXT_FILE, "a") as searched_words:
         searched_words.write(f"{word}: {first_matches}\n")
 
-    update_or_add_word(word, first_matches, lang)
+    _update_or_add_word(word, first_matches, lang)
 
-    print(f'{result.n_results} matches - first {matches_to_show}: {first_matches}')
+    print(f"{result.n_results} matches - first {matches_to_show}: {first_matches}")
 
-def load_words(filename: str) -> List[SearchedWord]:
+
+def _load_words(filename: str) -> List[SearchedWord]:
     try:
-        with open(filename, 'r', encoding='utf-8') as f:
+        with open(filename, "r", encoding="utf-8") as f:
             data = json.load(f)
             return [SearchedWord.from_json(item) for item in data]
     except (FileNotFoundError, json.JSONDecodeError):
         return []
 
-def save_words(words: List[SearchedWord], filename: str):
-    with open(filename, 'w', encoding='utf-8') as f:
+
+def _save_words(words: List[SearchedWord], filename: str):
+    with open(filename, "w", encoding="utf-8") as f:
         json.dump([word.to_json() for word in words], f, indent=2)
 
-def update_or_add_word(new_word: str, definition: str, lang: str):
-    words = load_words(JSON_FILE)
+
+def _update_or_add_word(new_word: str, definition: str, lang: str):
+    words = _load_words(JSON_FILE)
     now = datetime.now()
 
     for word in words:
@@ -62,11 +66,12 @@ def update_or_add_word(new_word: str, definition: str, lang: str):
             lang=lang,
             first_searched=now,
             last_searched=now,
-            times_searched=1
+            times_searched=1,
         )
         words.append(searched_word)
 
-    save_words(words, JSON_FILE)
+    _save_words(words, JSON_FILE)
+
 
 def _fetch_result(word, from_english):
     translator = Dict()
@@ -76,7 +81,42 @@ def _fetch_result(word, from_english):
         return translator.translate(word, from_language="de", to_language="en")
 
 
-if __name__ == '__main__':
+def _get_first_matches(matches_to_show, translation_tuples):
+    basic_translations = _remove_translations_with_square_brackets(
+        translation_tuples
+    )
+    # If all translations were filtered out, we still want to show the first few matches
+    if not basic_translations:
+        basic_translations = _remove_text_in_square_brackets_from_translation(
+            translation_tuples
+        )
+    first_matches = " - ".join(
+        [translation[1] for translation in basic_translations[:matches_to_show]]
+    )
+    return first_matches
+
+
+def _remove_translations_with_square_brackets(translation_tuples):
+    """
+    Remove translations that contain square brackets, as these examples are usually not useful for quick translations.
+    :param translation_tuples: list[tuple[str, str]]
+    :return: list[tuple[str, str]]
+    """
+    return list(filterfalse(lambda tup: "[" in tup[1], translation_tuples))
+
+
+def _remove_text_in_square_brackets_from_translation(translation_tuples):
+    """
+    Remove text in square brackets from translations, as they are often not relevant for quick translations.
+    :param translation_tuples: list[tuple[str, str]]
+    :return: list[tuple[str, str]]
+    """
+    return list(
+        map(lambda tup: (tup[0], sub(r"\[.*]", "", tup[1]).strip()), translation_tuples)
+    )
+
+
+if __name__ == "__main__":
     parser = ArgumentParser(
         prog=Path(__file__).stem,
         description="Get quick translations between German and English",
@@ -101,15 +141,14 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if args.from_german and args.from_english:
-        print('only one of --from-german (-d) or --from-english (-e) can be provided')
+        print("only one of --from-german (-d) or --from-english (-e) can be provided")
         exit(-1)
 
     if not args.from_german and not args.from_english:
-        print('one of --from-german (-d) or --from-english (-e) must be provided')
+        print("one of --from-german (-d) or --from-english (-e) must be provided")
         exit(-1)
 
     if args.from_german:
         translate(args.from_german, args.matches_to_show)
     else:
         translate(args.from_english, args.matches_to_show, from_english=True)
-


### PR DESCRIPTION
When all results contained brackets, we were returning 0 results even when some existed.

We can easily remove the text in brackets instead.

Example German word to reproduce: "Meerrettich"

Also ran auto-formatter using `black`.
